### PR TITLE
Support dismissing the view

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ function openUrl(url, readerMode) {
     }
   })
 }
+
+function dismissSafari() {
+  SafariViewController.hide()
+}
 ```
 
 ## 5. Advantages over InAppBrowser

--- a/demo/index.html
+++ b/demo/index.html
@@ -22,7 +22,8 @@
     <p class="event received">Device is Ready</p>
     <br/>
     <button onclick="openUrl('https://en.m.wikipedia.org/wiki/Safari', false)">Open Wikipedia</button><br/><br/>
-    <button onclick="openUrl('https://en.m.wikipedia.org/wiki/Safari', true)">Open Wikipedia in reader mode</button>
+    <button onclick="openUrl('https://en.m.wikipedia.org/wiki/Safari', true)">Open Wikipedia in reader mode</button><br/><br/>
+    <button onclick="openUrl('https://en.m.wikipedia.org/wiki/Safari', false);setTimeout(dismissSafari, 10000)">Open Wikipedia, automatically dismiss after 10 seconds</button>
   </div>
 </div>
 <script type="text/javascript" src="cordova.js"></script>
@@ -46,6 +47,10 @@
         window.open(url /*, '_blank', 'location=yes'*/);
       }
     })
+  }
+
+  function dismissSafari() {
+    SafariViewController.hide()
   }
 </script>
 </body>

--- a/src/ios/SafariViewController.h
+++ b/src/ios/SafariViewController.h
@@ -5,5 +5,6 @@
 
 - (void) isAvailable:(CDVInvokedUrlCommand*)command;
 - (void) show:(CDVInvokedUrlCommand*)command;
+- (void) hide:(CDVInvokedUrlCommand*)command;
 
 @end

--- a/src/ios/SafariViewController.m
+++ b/src/ios/SafariViewController.m
@@ -1,6 +1,9 @@
 #import "SafariViewController.h"
 
 @implementation SafariViewController
+{
+  SFSafariViewController *vc;
+}
 
 - (void) isAvailable:(CDVInvokedUrlCommand*)command {
   bool avail = NSClassFromString(@"SFSafariViewController") != nil;
@@ -19,9 +22,17 @@
   NSURL *url = [NSURL URLWithString:urlString];
   bool readerMode = [[options objectForKey:@"enterReaderModeIfAvailable"] isEqualToNumber:[NSNumber numberWithBool:YES]];
 
-  SFSafariViewController *vc = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:readerMode];
+  vc = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:readerMode];
   vc.delegate = self;
   [self.viewController presentViewController:vc animated:YES completion:nil];
+  [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+}
+
+- (void) hide:(CDVInvokedUrlCommand*)command {
+  if (vc != nil) {
+    [vc dismissViewControllerAnimated:YES completion:nil];
+    vc = nil;
+  }
   [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
 }
 

--- a/www/SafariViewController.js
+++ b/www/SafariViewController.js
@@ -5,5 +5,8 @@ module.exports = {
   },
   show: function (options, onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "show", [options]);
+  },
+  hide: function (onSuccess, onError) {
+    exec(onSuccess, onError, "SafariViewController", "hide", []);
   }
 };


### PR DESCRIPTION
Thanks for writing this plugin! I'm using it as part of an auth flow so I need to dismiss the view once the user has signed in. I've hacked the plugin in my project but figured I'd share the changes here. Note that I'm far from a Cordova or Objective-C expert but this seems to work.

I've updated the example code and copy/pasted my changes to this repo, but I haven't tested it in a fresh project.

---

As an aside, perhaps the methods are better as `preset()` and `dismiss()` so they match the native interface?