### PR TITLE
Added an exit event

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,13 @@ function openUrl(url, readerMode) {
           },
           function(msg) {
             alert("KO: " + msg);
-          })
+          });
+
+        SafariViewController.addEventListener("exit", function onExit() {
+          console.log("Browser was dismissed");
+
+          SafariViewController.removeEventListener("exit", onExit);
+        });
     } else {
       // potentially powered by InAppBrowser because that (currently) clobbers window.open
       window.open(url, '_blank', 'location=yes');

--- a/demo/index.html
+++ b/demo/index.html
@@ -24,6 +24,10 @@
     <button onclick="openUrl('https://en.m.wikipedia.org/wiki/Safari', false)">Open Wikipedia</button><br/><br/>
     <button onclick="openUrl('https://en.m.wikipedia.org/wiki/Safari', true)">Open Wikipedia in reader mode</button><br/><br/>
     <button onclick="openUrl('https://en.m.wikipedia.org/wiki/Safari', false);setTimeout(dismissSafari, 10000)">Open Wikipedia, auto-dismiss after 10s</button>
+
+    <p>Events</o>
+    <br/>
+    <input type="checkbox" name="exit" onchange="toggleEventAlert(this.checked, this.name, 'Browser was dismissed')">
   </div>
 </div>
 <script type="text/javascript" src="cordova.js"></script>
@@ -51,6 +55,25 @@
 
   function dismissSafari() {
     SafariViewController.hide()
+  }
+
+  function addEventAlert(eventName, alertMessage) {
+    SafariViewController.addEventListener(eventName, function() {
+      alert(alertMessage);
+    });
+  }
+
+  function removeEvent(eventName) {
+    SafariViewController.removeEventListener(eventName);
+  }
+
+  function toggleEventAlert(on, eventName, alertMessage) {
+    if (on) {
+      addEventAlert(eventname, alertMessage);
+    }
+    else {
+      removeEvent(eventName);
+    }
   }
 </script>
 </body>

--- a/www/SafariViewController.js
+++ b/www/SafariViewController.js
@@ -1,12 +1,42 @@
 var exec = require("cordova/exec");
+var channel = require("cordova/channel");
+
+var channels = {
+  exit: channel.create("exit")
+};
+
+function eventHandler(event) {
+  if (event && (event.type in channels)) {
+    channels[event.type].fire(event);
+  }
+}
+
 module.exports = {
   isAvailable: function (onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "isAvailable", []);
   },
   show: function (options, onSuccess, onError) {
-    exec(onSuccess, onError, "SafariViewController", "show", [options]);
+    // This callback remains open for event handling; call onSuccess only once
+    // then await events.
+    exec(function(event) {
+      if (onSuccess) {
+        onSuccess.apply(null, arguments);
+        onSuccess = null;
+      }
+      eventHandler(event);
+    }, onError, "SafariViewController", "show", [options]);
   },
   hide: function (onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "hide", []);
+  },
+  addEventListener: function (eventname,f) {
+    if (eventname in channels) {
+      channels[eventname].subscribe(f);
+    }
+  },
+  removeEventListener: function(eventname, f) {
+    if (eventname in channels) {
+      channels[eventname].unsubscribe(f);
+    }
   }
 };


### PR DESCRIPTION
This implementation is similar to cordova-plugin-inappbrowser with the notable exception that `InAppBrowser` instances are created for each call to open a URL and any events are scoped to that particular instance. You don't need to remove events because they are not triggered the next time the browser is opened. In contrast, SafariViewController is a singleton and therefore the events may continue to fire for subsequent browser instances if not cleaned up. A particularly bad but not unlikely implementation would be to add an exit listener every time the browser is opened and never remove the listeners. 

Since there is only one event, currently it is easy to clean up the listener when it is called as shown in the demo. While the delegate does not allow nearly as much insight into the user's activity as in `UIWebView`, it is still possible that other events would be added (perhaps related to sharing) in which case a design closer to InAppBrowser may be an improvement.