### PR TITLE
Avoid a crash if the value for enterReaderModeIfAvailable is not boolean

### DIFF
--- a/src/ios/SafariViewController.m
+++ b/src/ios/SafariViewController.m
@@ -20,7 +20,7 @@
     return;
   }
   NSURL *url = [NSURL URLWithString:urlString];
-  bool readerMode = [[options objectForKey:@"enterReaderModeIfAvailable"] isEqualToNumber:[NSNumber numberWithBool:YES]];
+  bool readerMode = [[options objectForKey:@"enterReaderModeIfAvailable"] isEqual:[NSNumber numberWithBool:YES]];
 
   vc = [[SFSafariViewController alloc] initWithURL:url entersReaderIfAvailable:readerMode];
   vc.delegate = self;


### PR DESCRIPTION
I added an app preference allowing reader mode to be enabled by default, which is great except that by default the value I provided to `enterReaderModeIfAvailable` was `undefined` rather than `false`. It caused the app to crash because the value is expected to be an NSNumber when in fact it was an NSNull. Sloppy on my part, but simple enough to fix so that others may avoid the crash.