### PR TITLE
Correctly report SafariViewController availability for non-iOS platforms

### DIFF
--- a/www/SafariViewController.js
+++ b/www/SafariViewController.js
@@ -1,7 +1,13 @@
 var exec = require("cordova/exec");
 module.exports = {
   isAvailable: function (callback) {
-    exec(callback, null, "SafariViewController", "isAvailable", []);
+    var errorHandler = function errorHandler(error) {
+      // An error has occurred while trying to access the
+      // SafariViewController native implementation, most likely because
+      // we are on an unsupported platform.
+      callback(false);
+    };
+    exec(callback, errorHandler, "SafariViewController", "isAvailable", []);
   },
   show: function (options, onSuccess, onError) {
     var opts = options || {};


### PR DESCRIPTION
Make SafariViewController play nicely when called on platforms other
than iOS by returning `false` when `SafariViewController#isAvailable`
is called on these platforms.
Note that this will also correctly return availability if any other
error occurs while calling `SafariViewController#isAvailable` (e.g.
plugin not properly installed).