### PR TITLE
Add tint color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ function openUrl(url, readerMode) {
             hidden: false, // default false. You can use this to load cookies etc in the background (see issue #1 for details).
             animated: false, // default true, note that 'hide' will reuse this preference (the 'Done' button will always animate though)
             transition: 'curl', // unless animated is false you can choose from: curl, flip, fade, slide (default)
-            enterReaderModeIfAvailable: readerMode // default false
+            enterReaderModeIfAvailable: readerMode, // default false
+            tintColor: "#ff0000" // default is ios blue
           },
           // this success handler will be invoked for the lifecycle events 'opened', 'loaded' and 'closed'
           function(result) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -37,7 +37,8 @@
               hidden: false, // default false
               animated: true, // default true, note that 'hide' will reuse this preference (the 'Done' button will always animate though)
               transition: 'curl', // unless animated is false you can choose from: curl, flip, fade, slide (default)
-              enterReaderModeIfAvailable: readerMode // default false
+              enterReaderModeIfAvailable: readerMode, // default false
+              tintColor: "#ff0000" // default is ios blue
             },
             function(result) {
               if (result.event === 'opened') {

--- a/src/ios/SafariViewController.m
+++ b/src/ios/SafariViewController.m
@@ -42,6 +42,12 @@
       [self.viewController presentViewController:vc animated:NO completion:nil];
     }
   }
+  
+  NSString *tintColor = options[@"tintColor"];
+  if (tintColor != nil) {
+    vc.view.tintColor = [self colorFromHexString:options[@"tintColor"]];
+  }
+
 
   CDVPluginResult * pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:@{@"event":@"opened"}];
   [pluginResult setKeepCallback:[NSNumber numberWithBool:YES]];
@@ -60,6 +66,14 @@
   } else {
     return UIModalTransitionStyleCoverVertical;
   }
+}
+
+- (UIColor *)colorFromHexString:(NSString *)hexString {
+    unsigned rgbValue = 0;
+    NSScanner *scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1]; // bypass '#' character
+    [scanner scanHexInt:&rgbValue];
+    return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
 }
 
 - (void) hide:(CDVInvokedUrlCommand*)command {


### PR DESCRIPTION
This adds the ability to change the tint color of the web view (maybe what #10 was suggesting?).

Supplying `tintColor: #6BAC43` results in:

<img width="487" alt="screenshot 2016-03-19 00 27 58" src="https://cloud.githubusercontent.com/assets/816517/13896741/ef01d60a-ed6d-11e5-8c1b-9c9a639de882.png">

Also, it falls back to default iOS blue if no option is provided.

Any thoughts? Thanks!