### PR TITLE
[WIP] Chrome custome tabs

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -37,4 +37,14 @@
     <framework src="SafariServices.framework" weak="true"/>
   </platform>
 
+  <platform name="android">
+    <config-file target="config.xml" parent="/*">
+      <feature name="ChromeCustomTabPlugin">
+        <param name="android-package" value="com.cordovaplugin.ChromeCustomTabPlugin"/>
+      </feature>
+    </config-file>
+    <framework src="com.android.support:customtabs:23.2.0" />
+    <source-file src="src/android/ChromeCustomTabPlugin.java" target-dir="src/org/apache/cordova/plugin" />
+  </platform>
+
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,12 +39,17 @@
 
   <platform name="android">
     <config-file target="config.xml" parent="/*">
-      <feature name="ChromeCustomTabPlugin">
-        <param name="android-package" value="com.cordovaplugin.ChromeCustomTabPlugin"/>
+      <feature name="SafariViewController">
+        <param name="android-package" value="com.customtabsplugin.ChromeCustomTabPlugin"/>
+        <param name="onload" value="true" />
       </feature>
     </config-file>
     <framework src="com.android.support:customtabs:23.2.0" />
-    <source-file src="src/android/ChromeCustomTabPlugin.java" target-dir="src/org/apache/cordova/plugin" />
+
+    <source-file src="src/android/ChromeCustomTabPlugin.java"             target-dir="src/com/customtabsplugin" />
+    <source-file src="src/android/helpers/CustomTabsHelper.java"          target-dir="src/org/chromium/customtabsclient/shared" />
+    <source-file src="src/android/helpers/ServiceConnection.java"         target-dir="src/org/chromium/customtabsclient/shared" />
+    <source-file src="src/android/helpers/ServiceConnectionCallback.java" target-dir="src/org/chromium/customtabsclient/shared" />
   </platform>
 
 </plugin>

--- a/src/android/ChromeCustomTabPlugin.java
+++ b/src/android/ChromeCustomTabPlugin.java
@@ -1,12 +1,21 @@
-package com.cordovaplugin;
+package com.customtabsplugin;
 
 
+import android.content.Intent;
 import android.net.Uri;
+import android.support.customtabs.CustomTabsCallback;
+import android.support.customtabs.CustomTabsClient;
 import android.support.customtabs.CustomTabsIntent;
+import android.support.customtabs.CustomTabsServiceConnection;
+import android.support.customtabs.CustomTabsSession;
+import android.text.TextUtils;
 import android.util.Log;
 import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.PluginResult;
+import org.chromium.customtabsclient.shared.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,37 +23,146 @@ import org.json.JSONObject;
 /**
 * This class echoes a string called from JavaScript.
 */
-public class ChromeCustomTabPlugin extends CordovaPlugin {
+public class ChromeCustomTabPlugin extends CordovaPlugin implements ServiceConnectionCallback {
 
     public static final String TAG = "ChromeCustomTabPlugin";
+    public static final int CUSTOM_TAB_REQUEST_CODE = 1;
+
+    private CustomTabsSession mCustomTabsSession;
+    private CustomTabsClient mClient;
+    private CustomTabsServiceConnection mConnection;
+    private String mPackageNameToBind;
+    private boolean wasConnected;
+
+    @Override
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        mPackageNameToBind = CustomTabsHelper.getPackageNameToUse(cordova.getActivity());
+    }
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-        if (action.equals("isAvailable")) {
-            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
-            return true;
-        } else if (action.equals("show")) {
-            final JSONObject options = args.getJSONObject(0);
-            final String url = options.getString("url");
 
-            PluginResult pluginResult;
-            JSONObject result = new JSONObject();
-            try {
-                this.show(url);
-                result.put("event", "loaded");
-                pluginResult = new PluginResult(PluginResult.Status.OK, result);
-            } catch (Exception ex) {
-                result.put("error", ex.getMessage());
-                pluginResult = new PluginResult(PluginResult.Status.ERROR, result);
-            }
-            callbackContext.sendPluginResult(pluginResult);
-            return true;
+        switch (action) {
+            case "isAvailable":
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, isAvailable()));
+                return true;
+
+            case "show":
+                final JSONObject options = args.getJSONObject(0);
+                final String url = options.getString("url");
+
+                PluginResult pluginResult;
+                JSONObject result = new JSONObject();
+                try {
+                    this.show(url);
+                    result.put("event", "loaded");
+                    pluginResult = new PluginResult(PluginResult.Status.OK, result);
+                } catch (Exception ex) {
+                    result.put("error", ex.getMessage());
+                    pluginResult = new PluginResult(PluginResult.Status.ERROR, result);
+                }
+                callbackContext.sendPluginResult(pluginResult);
+                return true;
+
+            case "connectToService":
+                bindCustomTabsService();
+                if (mConnection != null)
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
+                else
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, "Failed to connect to service"));
+                return true;
+
+            case "warmUp":
+                if (warmUp()) {
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
+                } else {
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.ERROR, "Failed to warm up service"));
+                }
+                return true;
         }
         return false;
     }
 
+    private boolean isAvailable(){
+        return !TextUtils.isEmpty(mPackageNameToBind);
+    }
+
     private void show(String url) {
-        CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
-        customTabsIntent.launchUrl(cordova.getActivity(), Uri.parse(url));
+        CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder(getSession()).build();
+        Intent intent = customTabsIntent.intent;
+        intent.setData(Uri.parse(url));
+        cordova.startActivityForResult(this, intent, CUSTOM_TAB_REQUEST_CODE);
+    }
+
+    private boolean warmUp(){
+        boolean success = false;
+        if (mClient != null) success = mClient.warmup(0);
+        return success;
+    }
+
+    private CustomTabsSession getSession() {
+        if (mClient == null) {
+            mCustomTabsSession = null;
+        } else if (mCustomTabsSession == null) {
+            mCustomTabsSession = mClient.newSession(new CustomTabsCallback());
+        }
+        return mCustomTabsSession;
+    }
+
+    private void bindCustomTabsService() {
+        if (mClient != null || !isAvailable()) return;
+
+        mConnection = new ServiceConnection(this);
+        boolean ok = CustomTabsClient.bindCustomTabsService(cordova.getActivity(), mPackageNameToBind, mConnection);
+        if(!ok) {
+            mConnection = null;
+        }
+    }
+
+    private void unbindCustomTabsService() {
+        if (mConnection == null) return;
+        cordova.getActivity().unbindService(mConnection);
+        mClient = null;
+        mCustomTabsSession = null;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+        super.onActivityResult(requestCode, resultCode, intent);
+        Log.d(TAG, String.format("requestCode: %d, resultCode: %d.", requestCode, resultCode));
+    }
+
+    @Override
+    public void onServiceConnected(CustomTabsClient client) {
+        mClient = client;
+    }
+
+    @Override
+    public void onServiceDisconnected() {
+        mClient = null;
+    }
+
+    @Override
+    public void onPause(boolean multitasking) {
+        if(mClient != null){
+            wasConnected = true;
+            unbindCustomTabsService();
+        }
+        super.onPause(multitasking);
+    }
+
+    @Override
+    public void onResume(boolean multitasking) {
+        if(wasConnected){
+            bindCustomTabsService();
+        }
+        super.onResume(multitasking);
+    }
+
+    @Override
+    public void onDestroy() {
+        unbindCustomTabsService();
+        super.onDestroy();
     }
 }

--- a/src/android/ChromeCustomTabPlugin.java
+++ b/src/android/ChromeCustomTabPlugin.java
@@ -1,0 +1,50 @@
+package com.cordovaplugin;
+
+
+import android.net.Uri;
+import android.support.customtabs.CustomTabsIntent;
+import android.util.Log;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+/**
+* This class echoes a string called from JavaScript.
+*/
+public class ChromeCustomTabPlugin extends CordovaPlugin {
+
+    public static final String TAG = "ChromeCustomTabPlugin";
+
+    @Override
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        if (action.equals("isAvailable")) {
+            callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
+            return true;
+        } else if (action.equals("show")) {
+            final JSONObject options = args.getJSONObject(0);
+            final String url = options.getString("url");
+
+            PluginResult pluginResult;
+            JSONObject result = new JSONObject();
+            try {
+                this.show(url);
+                result.put("event", "loaded");
+                pluginResult = new PluginResult(PluginResult.Status.OK, result);
+            } catch (Exception ex) {
+                result.put("error", ex.getMessage());
+                pluginResult = new PluginResult(PluginResult.Status.ERROR, result);
+            }
+            callbackContext.sendPluginResult(pluginResult);
+            return true;
+        }
+        return false;
+    }
+
+    private void show(String url) {
+        CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
+        customTabsIntent.launchUrl(cordova.getActivity(), Uri.parse(url));
+    }
+}

--- a/src/android/helpers/CustomTabsHelper.java
+++ b/src/android/helpers/CustomTabsHelper.java
@@ -1,0 +1,142 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.chromium.customtabsclient.shared;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.text.TextUtils;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Helper class for Custom Tabs.
+ */
+public class CustomTabsHelper {
+    private static final String TAG = "CustomTabsHelper";
+    static final String STABLE_PACKAGE = "com.android.chrome";
+    static final String BETA_PACKAGE = "com.chrome.beta";
+    static final String DEV_PACKAGE = "com.chrome.dev";
+    static final String LOCAL_PACKAGE = "com.google.android.apps.chrome";
+    private static final String EXTRA_CUSTOM_TABS_KEEP_ALIVE =
+            "android.support.customtabs.extra.KEEP_ALIVE";
+    private static final String ACTION_CUSTOM_TABS_CONNECTION =
+            "android.support.customtabs.action.CustomTabsService";
+
+    private static String sPackageNameToUse;
+
+    private CustomTabsHelper() {}
+
+//    public static void addKeepAliveExtra(Context context, Intent intent) {
+//        Intent keepAliveIntent = new Intent().setClassName(
+//                context.getPackageName(), KeepAliveService.class.getCanonicalName());
+//        intent.putExtra(EXTRA_CUSTOM_TABS_KEEP_ALIVE, keepAliveIntent);
+//    }
+
+    /**
+     * Goes through all apps that handle VIEW intents and have a warmup service. Picks
+     * the one chosen by the user if there is one, otherwise makes a best effort to return a
+     * valid package name.
+     *
+     * This is <strong>not</strong> threadsafe.
+     *
+     * @param context {@link Context} to use for accessing {@link PackageManager}.
+     * @return The package name recommended to use for connecting to custom tabs related components.
+     */
+    public static String getPackageNameToUse(Context context) {
+        if (sPackageNameToUse != null) return sPackageNameToUse;
+
+        PackageManager pm = context.getPackageManager();
+        // Get default VIEW intent handler.
+        Intent activityIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+        ResolveInfo defaultViewHandlerInfo = pm.resolveActivity(activityIntent, 0);
+        String defaultViewHandlerPackageName = null;
+        if (defaultViewHandlerInfo != null) {
+            defaultViewHandlerPackageName = defaultViewHandlerInfo.activityInfo.packageName;
+        }
+
+        // Get all apps that can handle VIEW intents.
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        List<String> packagesSupportingCustomTabs = new ArrayList<>();
+        for (ResolveInfo info : resolvedActivityList) {
+            Intent serviceIntent = new Intent();
+            serviceIntent.setAction(ACTION_CUSTOM_TABS_CONNECTION);
+            serviceIntent.setPackage(info.activityInfo.packageName);
+            if (pm.resolveService(serviceIntent, 0) != null) {
+                packagesSupportingCustomTabs.add(info.activityInfo.packageName);
+            }
+        }
+
+        // Now packagesSupportingCustomTabs contains all apps that can handle both VIEW intents
+        // and service calls.
+        if (packagesSupportingCustomTabs.isEmpty()) {
+            sPackageNameToUse = null;
+        } else if (packagesSupportingCustomTabs.size() == 1) {
+            sPackageNameToUse = packagesSupportingCustomTabs.get(0);
+        } else if (!TextUtils.isEmpty(defaultViewHandlerPackageName)
+                && !hasSpecializedHandlerIntents(context, activityIntent)
+                && packagesSupportingCustomTabs.contains(defaultViewHandlerPackageName)) {
+            sPackageNameToUse = defaultViewHandlerPackageName;
+        } else if (packagesSupportingCustomTabs.contains(STABLE_PACKAGE)) {
+            sPackageNameToUse = STABLE_PACKAGE;
+        } else if (packagesSupportingCustomTabs.contains(BETA_PACKAGE)) {
+            sPackageNameToUse = BETA_PACKAGE;
+        } else if (packagesSupportingCustomTabs.contains(DEV_PACKAGE)) {
+            sPackageNameToUse = DEV_PACKAGE;
+        } else if (packagesSupportingCustomTabs.contains(LOCAL_PACKAGE)) {
+            sPackageNameToUse = LOCAL_PACKAGE;
+        }
+        return sPackageNameToUse;
+    }
+
+    /**
+     * Used to check whether there is a specialized handler for a given intent.
+     * @param intent The intent to check with.
+     * @return Whether there is a specialized handler for the given intent.
+     */
+    private static boolean hasSpecializedHandlerIntents(Context context, Intent intent) {
+        try {
+            PackageManager pm = context.getPackageManager();
+            List<ResolveInfo> handlers = pm.queryIntentActivities(
+                    intent,
+                    PackageManager.GET_RESOLVED_FILTER);
+            if (handlers == null || handlers.size() == 0) {
+                return false;
+            }
+            for (ResolveInfo resolveInfo : handlers) {
+                IntentFilter filter = resolveInfo.filter;
+                if (filter == null) continue;
+                if (filter.countDataAuthorities() == 0 || filter.countDataPaths() == 0) continue;
+                if (resolveInfo.activityInfo == null) continue;
+                return true;
+            }
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Runtime exception while getting specialized handlers");
+        }
+        return false;
+    }
+
+    /**
+     * @return All possible chrome package names that provide custom tabs feature.
+     */
+    public static String[] getPackages() {
+        return new String[]{"", STABLE_PACKAGE, BETA_PACKAGE, DEV_PACKAGE, LOCAL_PACKAGE};
+    }
+}

--- a/src/android/helpers/ServiceConnection.java
+++ b/src/android/helpers/ServiceConnection.java
@@ -1,0 +1,46 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.chromium.customtabsclient.shared;
+
+import android.content.ComponentName;
+import android.support.customtabs.CustomTabsClient;
+import android.support.customtabs.CustomTabsServiceConnection;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Implementation for the CustomTabsServiceConnection that avoids leaking the
+ * ServiceConnectionCallback
+ */
+public class ServiceConnection extends CustomTabsServiceConnection {
+    // A weak reference to the ServiceConnectionCallback to avoid leaking it.
+    private WeakReference<ServiceConnectionCallback> mConnectionCallback;
+
+    public ServiceConnection(ServiceConnectionCallback connectionCallback) {
+        mConnectionCallback = new WeakReference<>(connectionCallback);
+    }
+
+    @Override
+    public void onCustomTabsServiceConnected(ComponentName name, CustomTabsClient client) {
+        ServiceConnectionCallback connectionCallback = mConnectionCallback.get();
+        if (connectionCallback != null) connectionCallback.onServiceConnected(client);
+    }
+
+    @Override
+    public void onServiceDisconnected(ComponentName name) {
+        ServiceConnectionCallback connectionCallback = mConnectionCallback.get();
+        if (connectionCallback != null) connectionCallback.onServiceDisconnected();
+    }
+}

--- a/src/android/helpers/ServiceConnectionCallback.java
+++ b/src/android/helpers/ServiceConnectionCallback.java
@@ -1,0 +1,33 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package org.chromium.customtabsclient.shared;
+
+import android.support.customtabs.CustomTabsClient;
+
+/**
+ * Callback for events when connecting and disconnecting from Custom Tabs Service.
+ */
+public interface ServiceConnectionCallback {
+    /**
+     * Called when the service is connected.
+     * @param client a CustomTabsClient
+     */
+    void onServiceConnected(CustomTabsClient client);
+
+    /**
+     * Called when the service is disconnected.
+     */
+    void onServiceDisconnected();
+}

--- a/www/SafariViewController.js
+++ b/www/SafariViewController.js
@@ -18,5 +18,11 @@ module.exports = {
   },
   hide: function (onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "hide", []);
+  },
+  connectToService: function (onSuccess, onError) {
+    exec(onSuccess, onError, "SafariViewController", "connectToService", []);
+  },
+  warmUp: function (onSuccess, onError) {
+    exec(onSuccess, onError, "SafariViewController", "warmUp", []);
   }
 };


### PR DESCRIPTION
Hi
I think this plugin is a good alternative for the InAppBrowser plugin in terms of UI and UX, and I thought why not give Android users some of that awesomeness with [Chrome Custom Tabs](https://developer.chrome.com/multidevice/android/customtabs) :)

> As of Chrome 45, Chrome Custom Tabs is now generally available to all users of Chrome, on all of Chrome's supported Android versions (Jellybean onwards).

There is still (a lot of) work to do on this PR, but I wanted to open it now in order to start a discussion.
Is this something you see fit in this plugin? If yes, I think we will need to change it's name ;)
The link above lists many advantagas of Custom Tabs over WebView. some of them, like [Warm up](https://developer.chrome.com/multidevice/android/customtabs#warm-up chrome to make pages load faster) or the [Custom Action button](https://developer.chrome.com/multidevice/android/customtabs#configure-a custom action button) requires us to extend this plugin's current set of APIs to allow developers take advantage of. does this seems relevant to you?

Work to be done:
- [x] Really implement the `isAvailable ` function by trying to connect to Chrome's service
- [ ] accept parametrs like transition animation, color and others in the `show` function
- [ ] implement `hide` so that cordova's javacscript code can close the tab (not sure this can be fully supported)
- [x] Implement a `warmUp` function
- [ ] accept action buttons argument in `show` (optional)
- [ ] Did I miss anything?