### PR TITLE
Add ability to show action items

### DIFF
--- a/src/ios/SafariViewController.h
+++ b/src/ios/SafariViewController.h
@@ -1,10 +1,19 @@
 #import <Cordova/CDVPlugin.h>
 #import <SafariServices/SafariServices.h>
 
+@protocol ActivityItemProvider
+
+- (NSArray<UIActivity *> *)safariViewController:(SFSafariViewController *)controller
+                            activityItemsForURL:(NSURL *)URL
+                                          title:(nullable NSString *)title;
+
+@end
+
 @interface SafariViewController : CDVPlugin <SFSafariViewControllerDelegate>
 
 @property (nonatomic, copy) NSString* callbackId;
 @property (nonatomic) bool animated;
+@property (nonatomic) id<ActivityItemProvider> activityItemProvider;
 
 - (void) isAvailable:(CDVInvokedUrlCommand*)command;
 - (void) show:(CDVInvokedUrlCommand*)command;

--- a/src/ios/SafariViewController.m
+++ b/src/ios/SafariViewController.m
@@ -143,4 +143,14 @@
   }
 }
 
+- (NSArray<UIActivity *> *)safariViewController:(SFSafariViewController *)
+              controller activityItemsForURL:(NSURL *)URL
+              title:(nullable NSString *)title {
+
+    if(self.activityItemProvider)
+        return [self.activityItemProvider safariViewController:controller activityItemsForURL:URL title:title];
+    else
+        return nil;
+}
+
 @end


### PR DESCRIPTION
Hello,

I would like to show an action item.
In the PR is the code that belongs into the library. Im app there must be code like this:

```
- (NSArray<UIActivity *> *)safariViewController:(SFSafariViewController *) controller
                            activityItemsForURL:(NSURL *)URL
                                          title:(nullable NSString *)title {
    MyActivity* activity = MyActivity.new;
    return @[activity];
}

@implementation MyActivity

- (NSString *)activityType {
...
}

- (NSString *)activityTitle {
...
}
...
@end

```
