### PR TITLE
Use flag PackageManager.MATCH_ALL to search all Android browsers

### DIFF
--- a/src/android/helpers/CustomTabsHelper.java
+++ b/src/android/helpers/CustomTabsHelper.java
@@ -73,7 +73,7 @@ public class CustomTabsHelper {
         }
 
         // Get all apps that can handle VIEW intents.
-        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, 0);
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(activityIntent, PackageManager.MATCH_ALL);
         List<String> packagesSupportingCustomTabs = new ArrayList<>();
         for (ResolveInfo info : resolvedActivityList) {
             Intent serviceIntent = new Intent();


### PR DESCRIPTION
Potential fix for #58.   

The existing implementation only queries for the default browser when pulling app candidates with the ACTION_VIEW intent.  For example, if Samsung's "Internet" browser application (running Chromium 44) is set as default, even with Chrome installed, isAvailable() will return false.  This change more closely aligns with the comment on [line 75](https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller/blob/master/src/android/helpers/CustomTabsHelper.java#L75)