### PR TITLE
Encode URL

### DIFF
--- a/src/ios/SafariViewController.m
+++ b/src/ios/SafariViewController.m
@@ -22,6 +22,7 @@
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"url must start with http or https"] callbackId:command.callbackId];
     return;
   }
+  urlString = [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
   NSURL *url = [NSURL URLWithString:urlString];
   if (url == nil) {
     [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"bad url"] callbackId:command.callbackId];


### PR DESCRIPTION
Issue: Fail to access a url with foreign language, such as https://twitter.com/hashtag/%EC%83%A4%EC%9D%B4%EB%8B%88_9%EB%85%84%EB%8F%99%EC%95%88_%EB%B9%9B%EB%82%98%EC%A4%98%EC%84%9C_%EA%B3%A0%EB%A7%88%EC%9B%8C?src=hash

Solution: Encoded the URL with stringByAddingPercentEscapesUsingEncoding. 

Ref: https://stackoverflow.com/questions/31131165/why-to-use-stringbyaddingpercentescapesusingencoding