### PR TITLE
Compiling with java 1.8

### DIFF
--- a/build/android/SafariViewController-java17.gradle
+++ b/build/android/SafariViewController-java17.gradle
@@ -1,8 +1,0 @@
-ext.postBuildExtras = {
-    android {
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_7
-            targetCompatibility JavaVersion.VERSION_1_7
-        }
-    }
-}

--- a/build/android/SafariViewController-java18.gradle
+++ b/build/android/SafariViewController-java18.gradle
@@ -1,0 +1,8 @@
+ext.postBuildExtras = {
+    android {
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
+    }
+}

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,7 @@
         <param name="onload" value="true" />
       </feature>
     </config-file>
-    <framework src="build/android/SafariViewController-java17.gradle" custom="true" type="gradleReference" />
+    <framework src="build/android/SafariViewController-java18.gradle" custom="true" type="gradleReference" />
     <framework src="com.android.support:customtabs:23.2.0" />
 
     <source-file src="src/android/ChromeCustomTabPlugin.java"             target-dir="src/com/customtabplugin" />


### PR DESCRIPTION
Android studio 3.0 is needed 
https://developer.android.com/studio/write/java8-support.html

If you have a lower version of android studio you need to have jack enabled(deprecated)
You can enable jack compiler by adding following line in build.gradle file.
```
defaultConfig {
    ...
    jackOptions {
        enabled true
    }
}
```

The compiling with java 1.8 is also needed to fix a compatibility with phonegap-plugin-push plugin :
https://github.com/phonegap/phonegap-plugin-push/issues/1800

The phonegap-plugin-push plugin is one of the most used plugins ([35,391 downloads in the last month](https://www.npmjs.com/package/phonegap-plugin-push))