### PR TITLE
Updated readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ function dismissSafari() {
 * InAppBrowser uses the slow UIWebView (even when you're using a WKWebView plugin!), this plugin uses the ultra fast Safari Webview.
 * This is now Apple's recommended way to use a browser in your app.
 * A nicer / cleaner UI which is consistent with Safari and all other apps using a `SFSafariViewController`.
-* Since this is the system's main browser, assets like cookies are shared with your app, so the user is still logged on in his favorite websites.
 * Whereas `cordova-plugin-inappbrowser` is affected by [ATS](https://developer.apple.com/library/prerelease/ios/technotes/App-Transport-Security-Technote/), this plugin is not. This means you can even load `http` URL's without whitelisting them.
 * Since iOS 9.2 or 9.3 you can swipe to go back to your app. Unfortunately, in favor of this Apple dropped the option to provide a custom transition (curl/flip/..) when presenting Safari.
 


### PR DESCRIPTION
Since iOS 11 Safari and other apps get their own cookies and website data.

This means that cookies, local storage, and other browsing data will be contained within your app and scoped to your app. And this means that the user won't automatically be logged in to whatever accounts they were logged into in Safari. What this does is it will prevent cross-app tracking of user's browsing activity that you and your users may not have even been aware about. And ultimately, it helps keep users' browsing activity private and scoped within your app.

https://developer.apple.com/videos/play/wwdc2017/225

So the following point of "Advantages over InAppBrowser" section is not valid anymore:
"Since this is the system's main browser, assets like cookies are shared with your app, so the user is still logged on in his favorite websites."