### PR TITLE
fix: childViewController removed correctly on hide

### DIFF
--- a/src/ios/SafariViewController.m
+++ b/src/ios/SafariViewController.m
@@ -109,6 +109,14 @@
 }
 
 - (void) hide:(CDVInvokedUrlCommand*)command {
+  SFSafariViewController *childVc = [self.viewController.childViewControllers lastObject];
+  if (childVc != nil) {
+    [childVc willMoveToParentViewController:nil];
+    [childVc.view removeFromSuperview];
+    [childVc removeFromParentViewController];
+    childVc = nil;
+  }
+  
   if (vc != nil) {
     [vc dismissViewControllerAnimated:self.animated completion:nil];
     vc = nil;


### PR DESCRIPTION
When 'hidden' is specified for a tab, it gets added as a childView to the viewController, but did not get removed again on hide().