### PR TITLE
Lower required Java version to 1.7

### DIFF
--- a/build/android/SafariViewController-java18.gradle
+++ b/build/android/SafariViewController-java18.gradle
@@ -1,8 +1,8 @@
 ext.postBuildExtras = {
     android {
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
+            sourceCompatibility JavaVersion.VERSION_1_7
+            targetCompatibility JavaVersion.VERSION_1_7
         }
     }
 }


### PR DESCRIPTION
This fixes the problems described in #114 
As the plugin does not use language features which are specific to Java version 1.8 it can be lowered to 1.7 which does not require jack to compile.

Cheers
David