### PR TITLE
Use cdvPluginPostBuildExtras to avoid plugin conflicts

### DIFF
--- a/build/android/SafariViewController-java18.gradle
+++ b/build/android/SafariViewController-java18.gradle
@@ -1,8 +1,8 @@
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     android {
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
         }
     }
-}
+})


### PR DESCRIPTION
Many people use this plugin together with https://github.com/phonegap/phonegap-plugin-push, which has a dependency that also uses `ext.postBuildExtras`. (there's a PR similar to this for https://github.com/chemerisuk/cordova-support-google-services/pull/17)

If the build process decides to include this plugin's postBuildExtras after cordova-support-google-services' postBuildExtras, then the push plugin won't get applied since it gets overwritten by this plugin, causing the issues https://github.com/phonegap/phonegap-plugin-push/issues/1800 and https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller/issues/84.

By using [cdvPluginPostBuildExtras.add](https://github.com/apache/cordova-android/blob/576edb53bb5b6f9be4ffb1348f1efbeeb2968905/bin/templates/project/app/build.gradle#L89), multiple plugins can use postBuildExtras without overwriting each other.