### PR TITLE
Add API to use a specific Custom Tabs implementation

### DIFF
--- a/src/android/ChromeCustomTabPlugin.java
+++ b/src/android/ChromeCustomTabPlugin.java
@@ -2,6 +2,7 @@ package com.customtabplugin;
 
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
 import android.net.Uri;
@@ -43,6 +44,7 @@ public class ChromeCustomTabPlugin extends CordovaPlugin{
 
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        final Context context = this.cordova.getContext();
 
         switch (action) {
             case "isAvailable":
@@ -87,6 +89,33 @@ public class ChromeCustomTabPlugin extends CordovaPlugin{
                 callbackContext.sendPluginResult(pluginResult);
                 return true;
             }
+            case "getViewHandlerPackages": {
+                PluginResult pluginResult;
+                final JSONObject result = new JSONObject();
+                result.put("defaultHandler", CustomTabsHelper.getDefaultViewHandlerPackageName(context));
+                result.put("customTabsImplementations", new JSONArray(CustomTabsHelper.getPackagesSupportingCustomTabs(context)));
+                pluginResult = new PluginResult(PluginResult.Status.OK, result);
+                callbackContext.sendPluginResult(pluginResult);
+                return true;
+            }
+            case "useCustomTabsImplementation": {
+                PluginResult pluginResult;
+                JSONObject result = new JSONObject();
+                final String packageName = args.optString(0);
+                if(TextUtils.isEmpty(packageName)) {
+                    result.put("error", "expected argument 'packageName' to be non empty string.");
+                    pluginResult = new PluginResult(PluginResult.Status.ERROR, result);
+                } else {
+                    try {
+                        mCustomTabPluginHelper.setPackageNameToBind(packageName, context);
+                        pluginResult = new PluginResult(PluginResult.Status.OK, true);
+                    } catch (CustomTabsHelper.InvalidPackageException e) {
+                        pluginResult = new PluginResult(PluginResult.Status.ERROR, "Invalid package: "+packageName);
+                    }
+                }
+                callbackContext.sendPluginResult(pluginResult);
+                return true;
+            }
             case "connectToService": {
                 if (bindCustomTabsService())
                     callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
@@ -126,10 +155,10 @@ public class ChromeCustomTabPlugin extends CordovaPlugin{
             builder.addDefaultShareMenuItem();
         if(!TextUtils.isEmpty(transition))
             addTransition(builder, transition);
-       
+
 
         CustomTabsIntent customTabsIntent = builder.build();
-        
+
         String packageName = CustomTabsHelper.getPackageNameToUse(cordova.getActivity());
         if ( packageName != null ) {
            customTabsIntent.intent.setPackage(packageName);

--- a/src/android/helpers/CustomTabServiceHelper.java
+++ b/src/android/helpers/CustomTabServiceHelper.java
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public class CustomTabServiceHelper implements ServiceConnectionCallback {
 
-    private final String mPackageNameToBind;
+    private String mPackageNameToBind;
     private CustomTabsSession mCustomTabsSession;
     private CustomTabsClient mClient;
     private CustomTabsServiceConnection mConnection;
@@ -36,6 +36,11 @@ public class CustomTabServiceHelper implements ServiceConnectionCallback {
 
     public boolean isAvailable(){
         return !TextUtils.isEmpty(mPackageNameToBind);
+    }
+
+    public void setPackageNameToBind(String packageName, Context context) throws CustomTabsHelper.InvalidPackageException {
+        CustomTabsHelper.setPackageNameToUse(packageName, context);
+        mPackageNameToBind = packageName;
     }
 
     /**

--- a/www/SafariViewController.js
+++ b/www/SafariViewController.js
@@ -19,6 +19,12 @@ module.exports = {
   hide: function (onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "hide", []);
   },
+  getViewHandlerPackages: function (onSuccess, onError) {
+    exec(onSuccess, onError, "SafariViewController", "getViewHandlerPackages", []);
+  },
+  useCustomTabsImplementation: function (packageName, onSuccess, onError) {
+    exec(onSuccess, onError, "SafariViewController", "useCustomTabsImplementation", [packageName]);
+  },
   connectToService: function (onSuccess, onError) {
     exec(onSuccess, onError, "SafariViewController", "connectToService", []);
   },


### PR DESCRIPTION
#### What I did
On the Android platform through the `useCustomTabsImplementation(packageName)` API I made it possible to select any of the available Custom Tabs implementations for the in-app-browser, in case the default one is not preferable.

See https://github.com/doxo/cordova-plugin-safariviewcontroller/pull/1