### PR TITLE
Enable "SafariViewController.hide()" for Chrome Custom Tabs

### DIFF
--- a/src/android/ChromeCustomTabPlugin.java
+++ b/src/android/ChromeCustomTabPlugin.java
@@ -139,6 +139,10 @@ public class ChromeCustomTabPlugin extends CordovaPlugin{
                 }
                 return true;
             }
+            case "hide": {
+                cordova.getActivity().startActivity(new Intent(cordova.getActivity(), cordova.getActivity().getClass()));
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
Implemented fix as discussed in https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller/issues/105. Tested and is working fine in my use-case. 

Works with and without `<preference name="AndroidLaunchMode" value="singleTask" />`. Although without the preference, `SafariViewController.hide()` causes a new "layer" of the Cordova app to be instantiated. This means that after manually calling `SafariViewController.hide()` the app's user would lose their place within the app because it's essentially restarting from what I can tell. Because of this, I would recommend that `<preference name="AndroidLaunchMode" value="singleTask" />` is added.

Not sure that this would resolve https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller/issues/105, but it does enable `SafariViewController.hide()` to function on Android as it does iOS.