### PR TITLE
Android 11 package visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Do this:
 
 
 ## 7. Changelog
+* 2.0.1 Make Chrome Custom Tabs work on Android 11. Thanks #179!
 * 2.0.0 Support AndroidX
 * 1.6.0 A few changes for Android. See [these closed issues](https://github.com/EddyVerbruggen/cordova-plugin-safariviewcontroller/milestone/7?closed=1).
 * 1.5.3 Hidden tabs don't get removed on `hide()` (iOS). Thanks #104!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-safariviewcontroller",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Forget InAppBrowser for iOS - this is way better for displaying read-only web content in your PhoneGap app.",
   "cordova": {
     "id": "cordova-plugin-safariviewcontroller",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <plugin
     id="cordova-plugin-safariviewcontroller"
-    version="2.0.0"
+    version="2.0.1"
     xmlns="http://apache.org/cordova/ns/plugins/1.0">
 
   <name>SafariViewController</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,6 +44,15 @@
         <param name="onload" value="true" />
       </feature>
     </config-file>
+
+    <config-file target="AndroidManifest.xml" parent="/manifest">
+      <queries>
+        <intent>
+          <action android:name="android.support.customtabs.action.CustomTabsService" />
+        </intent>
+      </queries>
+    </config-file>
+
     <framework src="build/android/SafariViewController-java18.gradle" custom="true" type="gradleReference" />
     <framework src="androidx.browser:browser:1.3.0" />
 


### PR DESCRIPTION
Implemented fix discussed in #179. Tested and is working fine on my devices and emulators.

See https://developer.android.com/training/package-visibility for details.