### PR TITLE
Update SafariViewController to support Android SDK 35

### DIFF
--- a/build/android/SafariViewController-java18.gradle
+++ b/build/android/SafariViewController-java18.gradle
@@ -1,8 +1,8 @@
 cdvPluginPostBuildExtras.add({
     android {
         compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
+            sourceCompatibility JavaVersion.VERSION_11
+            targetCompatibility JavaVersion.VERSION_11
         }
     }
 })


### PR DESCRIPTION
As per the Cordova Android 14.0.0, Java version has been updated to jdk 11.


https://cordova.apache.org/announcements/2025/03/26/cordova-android-14.0.0.html#:~:text=Increased%20Java%20Source%20%26%20Target%20Compatibility