### PR TITLE
Remove forced Java version

### DIFF
--- a/build/android/SafariViewController-java18.gradle
+++ b/build/android/SafariViewController-java18.gradle
@@ -1,8 +1,0 @@
-cdvPluginPostBuildExtras.add({
-    android {
-        compileOptions {
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
-        }
-    }
-})

--- a/plugin.xml
+++ b/plugin.xml
@@ -44,7 +44,6 @@
         <param name="onload" value="true" />
       </feature>
     </config-file>
-    <framework src="build/android/SafariViewController-java18.gradle" custom="true" type="gradleReference" />
     <framework src="androidx.browser:browser:1.3.0" />
 
     <source-file src="src/android/ChromeCustomTabPlugin.java"             target-dir="src/com/customtabplugin" />


### PR DESCRIPTION
Hi! 

I believe forcing a specific Java version is outdated. This PR should solve issues like https://github.com/4ian/GDevelop/issues/7743 where Java version of this plugin is conflicting with a newer Java version used by Cordova (be it Java or Kotlin).

This was tested locally on a Cordova project where I manually removed the lines removed in this PR.

Alternatively, Java version could be set to 11 like done in PR #190 - not sure what's the best.